### PR TITLE
Add read NFC tags functionality

### DIFF
--- a/nfc_flutter/android/app/build.gradle
+++ b/nfc_flutter/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.nfc_flutter"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/nfc_flutter/android/app/src/main/AndroidManifest.xml
+++ b/nfc_flutter/android/app/src/main/AndroidManifest.xml
@@ -38,4 +38,5 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <uses-permission android:name="android.permission.NFC"/>
 </manifest>

--- a/nfc_flutter/android/app/src/main/AndroidManifest.xml
+++ b/nfc_flutter/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.nfc_flutter">
    <application
-        android:label="nfc_flutter"
+        android:label="NFC Flutter"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/nfc_flutter/lib/Utils/nfc_functions.dart
+++ b/nfc_flutter/lib/Utils/nfc_functions.dart
@@ -5,7 +5,7 @@ import 'package:nfc_manager/nfc_manager.dart';
 Future<bool> readNFC(BuildContext context) async {
   // Check availability
   bool isAvailable = await NfcManager.instance.isAvailable();
-
+  // On NFC functionality available or active
   if (isAvailable) {
     // Pop in awaiting for NFC tag dialog
     showDialog(
@@ -71,7 +71,6 @@ Future<bool> readNFC(BuildContext context) async {
         context: context,
         builder: (context) => AlertDialogComponent(
               isSingleButton: true,
-              // okButtonBorderColor: Colors.transparent,
               okButtonHighlightColor: Colors.grey.shade300,
               okButtonBorderRadius: 10,
               borderColor: Colors.transparent,
@@ -86,4 +85,8 @@ Future<bool> readNFC(BuildContext context) async {
     return false;
   }
   return true;
+}
+
+Future<bool> writeNFC(BuildContext context, String data) async {
+  return false;
 }

--- a/nfc_flutter/lib/Utils/read_nfc_tag.dart
+++ b/nfc_flutter/lib/Utils/read_nfc_tag.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:nfc_flutter/widgets/alertDialogComponent.dart';
+import 'package:nfc_manager/nfc_manager.dart';
+
+Future<bool> readNFC(BuildContext context) async {
+  // Check availability
+  bool isAvailable = await NfcManager.instance.isAvailable();
+
+  if (isAvailable) {
+    // Pop in awaiting for NFC tag dialog
+    showDialog(
+        context: context,
+        builder: (context) => AlertDialogComponent(
+              isSingleButton: true,
+              // okButtonBorderColor: Colors.transparent,
+              okButtonHighlightColor: Colors.grey.shade300,
+              okButtonBorderRadius: 10,
+              borderColor: Colors.transparent,
+              titleText: 'NFC',
+              descriptionText: 'Awaiting for NFC Tag',
+              okButtonText: 'Cancel',
+              onCancelCallback: () => null,
+              onOkCallback: () {
+                NfcManager.instance.stopSession();
+                Navigator.of(context).pop(true);
+              },
+            ));
+    // Start Session
+    NfcManager.instance.startSession(
+      onDiscovered: (tag) async {
+        // Do something with an NfcTag instance.
+        Ndef? ndef = Ndef.from(tag);
+        String hexTag = '';
+        for (int item in ndef?.additionalData.values.first) {
+          hexTag += item.toRadixString(16).padLeft(2, '0').toUpperCase();
+        }
+        print(hexTag);
+        print(ndef?.cachedMessage);
+        if (ndef == null) {
+          print('Tag is not compatible with NDEF');
+          // Stop Session
+          NfcManager.instance.stopSession();
+          return;
+        }
+        // Pop out awaiting dialog and pop in found tag dialog
+        Navigator.of(context).pop(true);
+        showDialog(
+            context: context,
+            builder: (context) => AlertDialogComponent(
+                  isSingleButton: true,
+                  // okButtonBorderColor: Colors.transparent,
+                  okButtonHighlightColor: Colors.grey.shade300,
+                  okButtonBorderRadius: 10,
+                  borderColor: Colors.transparent,
+                  titleText: 'NFC',
+                  descriptionText: 'NFC Tag found',
+                  okButtonText: 'Ok',
+                  onCancelCallback: () => null,
+                  onOkCallback: () {
+                    Navigator.of(context).pop(true);
+                  },
+                ));
+        // Stop Session
+        NfcManager.instance.stopSession();
+        return;
+      },
+    );
+  } else {
+    // Pop in NFC disabled dialog
+    showDialog(
+        context: context,
+        builder: (context) => AlertDialogComponent(
+              isSingleButton: true,
+              // okButtonBorderColor: Colors.transparent,
+              okButtonHighlightColor: Colors.grey.shade300,
+              okButtonBorderRadius: 10,
+              borderColor: Colors.transparent,
+              titleText: 'NFC',
+              descriptionText: 'NFC is not available or disabled',
+              okButtonText: 'Ok',
+              onCancelCallback: () => null,
+              onOkCallback: () {
+                Navigator.of(context).pop(true);
+              },
+            ));
+    return false;
+  }
+  return true;
+}

--- a/nfc_flutter/lib/Utils/router.dart
+++ b/nfc_flutter/lib/Utils/router.dart
@@ -1,0 +1,9 @@
+import 'package:nfc_flutter/views/views.dart';
+import 'package:auto_route/annotations.dart';
+
+@AdaptiveAutoRouter(
+  routes: <AutoRoute>[
+    AutoRoute(path: "/home", page: HomeView, initial: true),
+  ],
+)
+class $AppRouter {}

--- a/nfc_flutter/lib/Utils/router.gr.dart
+++ b/nfc_flutter/lib/Utils/router.gr.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// AutoRouteGenerator
+// **************************************************************************
+
+import 'package:auto_route/auto_route.dart' as _i1;
+import 'package:flutter/material.dart' as _i2;
+import 'package:nfc_flutter/views/views.dart' as _i3;
+
+class AppRouter extends _i1.RootStackRouter {
+  AppRouter([_i2.GlobalKey<_i2.NavigatorState>? navigatorKey])
+      : super(navigatorKey);
+
+  @override
+  final Map<String, _i1.PageFactory> pagesMap = {
+    HomeViewRoute.name: (routeData) => _i1.AdaptivePage<dynamic>(
+        routeData: routeData,
+        builder: (_) {
+          return const _i3.HomeView();
+        })
+  };
+
+  @override
+  List<_i1.RouteConfig> get routes => [
+        _i1.RouteConfig('/#redirect',
+            path: '/', redirectTo: '/home', fullMatch: true),
+        _i1.RouteConfig(HomeViewRoute.name, path: '/home')
+      ];
+}
+
+class HomeViewRoute extends _i1.PageRouteInfo {
+  const HomeViewRoute() : super(name, path: '/home');
+
+  static const String name = 'HomeViewRoute';
+}

--- a/nfc_flutter/lib/main.dart
+++ b/nfc_flutter/lib/main.dart
@@ -12,9 +12,9 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  final appRouter = AppRouter();
   @override
   Widget build(BuildContext context) {
-    final appRouter = AppRouter();
     return MaterialApp.router(
       routeInformationParser: appRouter.defaultRouteParser(),
       routerDelegate: appRouter.delegate(),

--- a/nfc_flutter/lib/main.dart
+++ b/nfc_flutter/lib/main.dart
@@ -1,14 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:nfc_flutter/Utils/router.gr.dart';
 
 void main() {
   runApp(MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   // This widget is the root of your application.
   @override
+  _MyAppState createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    final appRouter = AppRouter();
+    return MaterialApp.router(
+      routeInformationParser: appRouter.defaultRouteParser(),
+      routerDelegate: appRouter.delegate(),
       title: 'Flutter Demo',
       theme: ThemeData(
         // This is the theme of your application.
@@ -22,92 +31,6 @@ class MyApp extends StatelessWidget {
         // is not restarted.
         primarySwatch: Colors.blue,
       ),
-      home: MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  _MyHomePageState createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Invoke "debug painting" (press "p" in the console, choose the
-          // "Toggle Debug Paint" action from the Flutter Inspector in Android
-          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
-          // to see the wireframe for each widget.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/nfc_flutter/lib/views/home_view.dart
+++ b/nfc_flutter/lib/views/home_view.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:nfc_flutter/Utils/read_nfc_tag.dart';
+import 'package:nfc_flutter/widgets/actionButtonComponent.dart';
+import 'package:nfc_flutter/widgets/alertDialogComponent.dart';
 
 class HomeView extends StatefulWidget {
   const HomeView({Key? key}) : super(key: key);
@@ -13,7 +16,28 @@ class _HomeViewState extends State<HomeView> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        centerTitle: true,
         title: Text('Home'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ActionButtonComponent(
+                elevation: 5,
+                labelText: 'Read NFC Tag',
+                borderRadius: 10,
+                highlightColor: Colors.grey.shade300,
+                hoverColor: Colors.white,
+                onPressedCallback: () {
+                  readNFC(context);
+                },
+                onLongPressedCallback: () {}),
+            Text(
+              'Write NFC Tag',
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/nfc_flutter/lib/views/home_view.dart
+++ b/nfc_flutter/lib/views/home_view.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:nfc_flutter/Utils/read_nfc_tag.dart';
+import 'package:nfc_flutter/Utils/nfc_functions.dart';
 import 'package:nfc_flutter/widgets/actionButtonComponent.dart';
-import 'package:nfc_flutter/widgets/alertDialogComponent.dart';
 
 class HomeView extends StatefulWidget {
   const HomeView({Key? key}) : super(key: key);
@@ -23,6 +22,7 @@ class _HomeViewState extends State<HomeView> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            // Read NFC Tag button
             ActionButtonComponent(
                 elevation: 5,
                 labelText: 'Read NFC Tag',
@@ -34,7 +34,7 @@ class _HomeViewState extends State<HomeView> {
                 },
                 onLongPressedCallback: () {}),
             Text(
-              'Write NFC Tag',
+              'Write NFC Tag (WIP)',
             ),
           ],
         ),

--- a/nfc_flutter/lib/views/home_view.dart
+++ b/nfc_flutter/lib/views/home_view.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class HomeView extends StatefulWidget {
+  const HomeView({Key? key}) : super(key: key);
+
+  @override
+  _HomeViewState createState() => _HomeViewState();
+}
+
+class _HomeViewState extends State<HomeView> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Home'),
+      ),
+    );
+  }
+}

--- a/nfc_flutter/lib/views/home_view.dart
+++ b/nfc_flutter/lib/views/home_view.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
 import 'package:nfc_flutter/Utils/nfc_functions.dart';
 import 'package:nfc_flutter/widgets/actionButtonComponent.dart';
 
@@ -10,7 +12,10 @@ class HomeView extends StatefulWidget {
   _HomeViewState createState() => _HomeViewState();
 }
 
+Widget? nfcInfo = Container();
+
 class _HomeViewState extends State<HomeView> {
+  NFCTag? tag;
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -22,6 +27,36 @@ class _HomeViewState extends State<HomeView> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            AnimatedSwitcher(
+              switchInCurve: Curves.decelerate,
+              transitionBuilder: (Widget child, Animation<double> animation) =>
+                  ScaleTransition(child: child, scale: animation),
+              duration: Duration(
+                seconds: 1,
+              ),
+              child: tag == null
+                  ? nfcInfo
+                  : Card(
+                      child: Column(
+                        children: [
+                          Text(
+                            'Identifier',
+                            textScaleFactor: 2,
+                          ),
+                          Divider(
+                            indent: 10,
+                            endIndent: 10,
+                            thickness: 2,
+                            color: Colors.black,
+                          ),
+                          Text(
+                            '${tag?.id}',
+                            textScaleFactor: 1.5,
+                          ),
+                        ],
+                      ),
+                    ),
+            ),
             // Read NFC Tag button
             ActionButtonComponent(
                 elevation: 5,
@@ -29,10 +64,17 @@ class _HomeViewState extends State<HomeView> {
                 borderRadius: 10,
                 highlightColor: Colors.grey.shade300,
                 hoverColor: Colors.white,
-                onPressedCallback: () {
-                  readNFC(context);
+                onPressedCallback: () async {
+                  setState(() {
+                    tag = null;
+                  });
+                  var result = await readNFC(context);
+                  setState(() {
+                    tag = result;
+                  });
                 },
                 onLongPressedCallback: () {}),
+            // TODO Write NFC Tag button
             Text(
               'Write NFC Tag (WIP)',
             ),

--- a/nfc_flutter/lib/views/home_view.dart
+++ b/nfc_flutter/lib/views/home_view.dart
@@ -27,36 +27,6 @@ class _HomeViewState extends State<HomeView> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            AnimatedSwitcher(
-              switchInCurve: Curves.decelerate,
-              transitionBuilder: (Widget child, Animation<double> animation) =>
-                  ScaleTransition(child: child, scale: animation),
-              duration: Duration(
-                seconds: 1,
-              ),
-              child: tag == null
-                  ? nfcInfo
-                  : Card(
-                      child: Column(
-                        children: [
-                          Text(
-                            'Identifier',
-                            textScaleFactor: 2,
-                          ),
-                          Divider(
-                            indent: 10,
-                            endIndent: 10,
-                            thickness: 2,
-                            color: Colors.black,
-                          ),
-                          Text(
-                            '${tag?.id}',
-                            textScaleFactor: 1.5,
-                          ),
-                        ],
-                      ),
-                    ),
-            ),
             // Read NFC Tag button
             ActionButtonComponent(
                 elevation: 5,
@@ -78,9 +48,79 @@ class _HomeViewState extends State<HomeView> {
             Text(
               'Write NFC Tag (WIP)',
             ),
+            // Tag data
+            TagData(tag: tag),
           ],
         ),
       ),
+    );
+  }
+}
+
+class TagData extends StatelessWidget {
+  const TagData({
+    Key? key,
+    required this.tag,
+  }) : super(key: key);
+
+  final NFCTag? tag;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      switchInCurve: Curves.decelerate,
+      transitionBuilder: (Widget child, Animation<double> animation) {
+        final offsetAnimation =
+            Tween<Offset>(begin: Offset(0.0, 5.0), end: Offset(0.0, 0.0))
+                .animate(animation);
+        return SlideTransition(
+          position: offsetAnimation,
+          child: child,
+        );
+      },
+      duration: Duration(
+        seconds: 1,
+      ),
+      child: tag == null
+          ? nfcInfo
+          : Card(
+              child: Column(
+                children: [
+                  Text(
+                    'Identifier',
+                    textScaleFactor: 2,
+                  ),
+                  Divider(
+                    indent: 10,
+                    endIndent: 10,
+                    thickness: 2,
+                    color: Colors.black,
+                  ),
+                  Text(
+                    '${tag?.id}',
+                    textScaleFactor: 1.5,
+                  ),
+                  Divider(
+                    indent: 10,
+                    endIndent: 10,
+                  ),
+                  Text(
+                    'Data',
+                    textScaleFactor: 2,
+                  ),
+                  Divider(
+                    indent: 10,
+                    endIndent: 10,
+                    thickness: 2,
+                    color: Colors.black,
+                  ),
+                  Text(
+                    '${tag?.applicationData}',
+                    textScaleFactor: 1.5,
+                  ),
+                ],
+              ),
+            ),
     );
   }
 }

--- a/nfc_flutter/lib/views/views.dart
+++ b/nfc_flutter/lib/views/views.dart
@@ -1,0 +1,1 @@
+export 'home_view.dart';

--- a/nfc_flutter/lib/widgets/actionButtonComponent.dart
+++ b/nfc_flutter/lib/widgets/actionButtonComponent.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+/// Class component for a design action button.
+///
+/// This component class depends of the following package:
+///
+/// * `font_awesome_flutter`
+///
+/// consider adding it to your dependencies on the `pubspec.yaml`
+/// file of the project.
+class ActionButtonComponent extends StatelessWidget {
+  /// The left padding of this component.
+  final double leftPadding;
+
+  /// The top padding of this component.
+  final double topPadding;
+
+  /// The right padding of this component.
+  final double rightPadding;
+
+  /// The bottom padding of this component.
+  final double bottomPadding;
+
+  /// The symmetric vertical padding of this component.
+  ///
+  /// This has priority over the [topPadding] and [bottomPadding] values.
+  final double? verticalPadding;
+
+  /// The symmetric horizontal padding of this component.
+  ///
+  /// This has proprity over the [leftPadding] and [rightPadding] values.
+  final double? horizontalPadding;
+
+  /// The spacing between the [prefixIcon], [labelText] and [suffixIcon] of this component.
+  final double contentSpacing;
+
+  /// The width of this component.
+  final double? width;
+
+  /// The height of this component.
+  final double? height;
+
+  /// The elevation of this component.
+  final double? elevation;
+
+  /// The text to display on this component.
+  final String labelText;
+
+  /// The text color of this component.
+  final Color textColor;
+
+  /// The text [onHover] color of this component.
+  final Color hoverTextColor;
+
+  /// The background color of this component.
+  final Color backgroundColor;
+
+  /// The highlight [onHover] color of this component.
+  final Color hoverColor;
+
+  /// The highlight [onPressed] color of this component. This also establishes
+  /// the [borderColor] for the [onPressed] state.
+  final Color highlightColor;
+
+  /// The border color of this component.
+  final Color borderColor;
+
+  /// The border radius (circular) of this component.
+  final double borderRadius;
+
+  /// The border radius (circular) [onPressed] of this component. If null, the
+  /// normal [borderRadius] is used instead.
+  final double? pressedBorderRadius;
+
+  /// The border width of this component.
+  final double borderWidth;
+
+  /// The border width [onPressed] of this component. If null, the normal
+  /// [borderWidth] is used instead.
+  final double? pressedBorderWidth;
+
+  /// Sets the prefix icon visible of this component.
+  final bool isPrefixIconVisible;
+
+  /// Sets the suffix icon visible of this component.
+  final bool isSuffixIconVisible;
+
+  /// The prefix icon of this component.
+  final IconData prefixIcon;
+
+  /// The suffix icon of this component.
+  final IconData suffixIcon;
+
+  /// The icons size of this component.
+  final double iconSize;
+
+  /// The font size of this component.
+  final double fontSize;
+
+  /// The [onPressed] callback function of this component.
+  final void Function() onPressedCallback;
+
+  /// The [onLongPressed] callback function of this component.
+  final void Function() onLongPressedCallback;
+
+  const ActionButtonComponent({
+    Key? key,
+    this.leftPadding = 0,
+    this.topPadding = 0,
+    this.rightPadding = 0,
+    this.bottomPadding = 0,
+    this.verticalPadding,
+    this.horizontalPadding,
+    this.contentSpacing = 10,
+    this.width,
+    this.height,
+    this.elevation = 0,
+    this.labelText = "Label text",
+    this.textColor = Colors.black,
+    this.hoverTextColor = Colors.white,
+    this.backgroundColor = Colors.white,
+    this.highlightColor = Colors.grey,
+    this.hoverColor = Colors.black,
+    this.borderColor = Colors.black,
+    this.borderRadius = 0,
+    this.borderWidth = 2,
+    this.pressedBorderRadius,
+    this.pressedBorderWidth,
+    this.isPrefixIconVisible = false,
+    this.isSuffixIconVisible = false,
+    this.prefixIcon = FontAwesomeIcons.icons,
+    this.suffixIcon = FontAwesomeIcons.icons,
+    this.fontSize = 24,
+    this.iconSize = 24,
+    required this.onPressedCallback,
+    required this.onLongPressedCallback,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: horizontalPadding ?? leftPadding,
+        top: verticalPadding ?? topPadding,
+        right: horizontalPadding ?? rightPadding,
+        bottom: verticalPadding ?? bottomPadding,
+      ),
+      child: SizedBox(
+        width: width,
+        height: height,
+        child: ElevatedButton(
+          style: ButtonStyle(
+            foregroundColor: MaterialStateProperty.resolveWith(
+              (states) {
+                return states.contains(MaterialState.hovered)
+                    ? hoverTextColor
+                    : textColor;
+              },
+            ),
+            backgroundColor: MaterialStateProperty.resolveWith((states) =>
+                states.contains(MaterialState.pressed)
+                    ? hoverColor
+                    : backgroundColor),
+            overlayColor: MaterialStateProperty.resolveWith(
+              (states) {
+                return states.contains(MaterialState.pressed)
+                    ? highlightColor
+                    : hoverColor;
+              },
+            ),
+            elevation: MaterialStateProperty.all(elevation),
+            shape: MaterialStateProperty.resolveWith(
+              (states) {
+                return states.contains(MaterialState.pressed)
+                    ? RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(
+                          pressedBorderRadius ?? borderRadius,
+                        ),
+                        side: BorderSide(
+                          width: pressedBorderWidth ?? borderWidth,
+                          color: highlightColor,
+                        ),
+                      )
+                    : RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(
+                          borderRadius,
+                        ),
+                        side: BorderSide(
+                          width: borderWidth,
+                          color: borderColor,
+                        ),
+                      );
+              },
+            ),
+          ),
+          onPressed: () {
+            onPressedCallback();
+          },
+          onLongPress: () {
+            onLongPressedCallback();
+          },
+          child: Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: contentSpacing,
+            children: [
+              (isPrefixIconVisible)
+                  ? Icon(
+                      prefixIcon,
+                      size: iconSize,
+                    )
+                  : Container(
+                      width: 0,
+                      height: 0,
+                    ),
+              Text(
+                labelText,
+                style: TextStyle(
+                  fontSize: fontSize,
+                ),
+              ),
+              (isSuffixIconVisible)
+                  ? Icon(
+                      suffixIcon,
+                      size: iconSize,
+                    )
+                  : Container(
+                      width: 0,
+                      height: 0,
+                    ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/nfc_flutter/lib/widgets/alertDialogComponent.dart
+++ b/nfc_flutter/lib/widgets/alertDialogComponent.dart
@@ -1,0 +1,304 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'actionButtonComponent.dart';
+
+/// Class component for an alert dialog.
+///
+/// This component class depends on the [actionButtonComponent], make sure
+/// that you have the component on your project added.
+class AlertDialogComponent extends StatefulWidget {
+  /// The background color of this component.
+  final Color backgroundColor;
+
+  /// The border color of this component.
+  final Color borderColor;
+
+  /// The border width of this component.
+  final double borderWidth;
+
+  /// The border radius of this component.
+  final double borderRadius;
+
+  /// The title text to display on this component.
+  final String titleText;
+
+  /// The title size of this component.
+  final double titleSize;
+
+  /// The title color of this component.
+  final Color titleColor;
+
+  /// The horizontal padding (for content width) of this component.
+  final double horizontalPadding;
+
+  /// Sets the simple description of this component.
+  ///
+  /// If set to [true], then only a [Text] with a description string will be
+  /// shown, otherwise a [widget] as description is required.
+  final bool isSimpleDescription;
+
+  /// The custom widget description of this component.
+  final Widget? customDescription;
+
+  /// The description text to display on this component.
+  final String descriptionText;
+
+  /// The description size of this component.
+  final double descriptionSize;
+
+  /// The description color of this component.
+  final Color descriptionColor;
+
+  /// Sets the single button of this component.
+  ///
+  /// If set to [true], then only [onOkCallback] cannot be null, otherwise
+  /// [onCancelCallback] cannot be null too.
+  final bool isSingleButton;
+
+  /// The cancel button width of this component.
+  final double? cancelButtonWidth;
+
+  /// The cancel button border radius of this component.
+  final double cancelButtonBorderRadius;
+
+  /// The cancel button border color of this component.
+  final Color cancelButtonBorderColor;
+
+  /// The cancel button hover color of this component.
+  final Color cancelButtonHoverColor;
+
+  /// The cancel button highlight color of this component.
+  final Color cancelButtonHighlightColor;
+
+  /// The cancel button background color of this component.
+  final Color cancelButtonBackgroundColor;
+
+  /// The cancel button text color of this component.
+  final Color cancelButtonTextColor;
+
+  /// The cancel button text to display on this component.
+  final String cancelButtonText;
+
+  /// The cancel button [onPressedCallback] callback function of this component.
+  final void Function() onCancelCallback;
+
+  /// The ok button width of this component.
+  final double? okButtonWidth;
+
+  /// The ok button border radius of this component.
+  final double okButtonBorderRadius;
+
+  /// The ok button border color of this component.
+  final Color okButtonBorderColor;
+
+  /// The ok button background color of this component.
+  final Color okButtonBackgroundColor;
+
+  /// The ok button hover color of this component.
+  final Color okButtonHoverColor;
+
+  /// The ok button highlight color of this component.
+  final Color okButtonHighlightColor;
+
+  /// The ok button text color of this component.
+  final Color okButtonTextColor;
+
+  /// The ok button text to display on this component.
+  final String okButtonText;
+
+  /// Sets the timer to activate buttons of this component.
+  ///
+  /// If set to [true], then [timerDuration] cannot be null.
+  final bool isTimerActive;
+
+  /// The duration fo the timer to activate buttons of this component.
+  final int timerDuration;
+
+  /// The ok button [onPressedCallback] callback function of this component.
+  final void Function() onOkCallback;
+
+  const AlertDialogComponent({
+    this.backgroundColor = Colors.white,
+    this.borderColor = Colors.black,
+    this.borderWidth = 2,
+    this.borderRadius = 10,
+    this.titleText = 'title text',
+    this.titleSize = 20,
+    this.titleColor = Colors.black,
+    this.horizontalPadding = 0,
+    this.isSimpleDescription = true,
+    this.customDescription,
+    this.descriptionText = 'description text',
+    this.descriptionSize = 20,
+    this.descriptionColor = Colors.black,
+    this.isSingleButton = false,
+    this.cancelButtonWidth,
+    this.cancelButtonBorderRadius = 0,
+    this.cancelButtonBorderColor = Colors.blueAccent,
+    this.cancelButtonBackgroundColor = Colors.white,
+    this.cancelButtonHighlightColor = Colors.grey,
+    this.cancelButtonHoverColor = Colors.white,
+    this.cancelButtonTextColor = Colors.black,
+    this.cancelButtonText = 'Cancel',
+    required this.onCancelCallback,
+    this.okButtonWidth,
+    this.okButtonBorderRadius = 0,
+    this.okButtonBorderColor = Colors.blueAccent,
+    this.okButtonBackgroundColor = Colors.white,
+    this.okButtonHighlightColor = Colors.grey,
+    this.okButtonHoverColor = Colors.white,
+    this.okButtonTextColor = Colors.black,
+    this.okButtonText = 'Ok',
+    required this.onOkCallback,
+    this.isTimerActive = false,
+    Key? key,
+    this.timerDuration = 3,
+  }) : super(key: key);
+
+  @override
+  _AlertDialogComponentState createState() => _AlertDialogComponentState();
+}
+
+class _AlertDialogComponentState extends State<AlertDialogComponent> {
+  /// If buttons are active
+  bool activeButtons = true;
+  int countTime = 0;
+
+  /// Start the countdown to activate buttons
+  void startCountDownTimer() {
+    countTime = 0;
+    if (widget.isTimerActive == true) {
+      activeButtons = false;
+      Timer.periodic(Duration(seconds: 1), (timer) {
+        if (countTime < widget.timerDuration)
+          countTime++;
+        else {
+          activeButtons = true;
+          timer.cancel();
+        }
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    startCountDownTimer();
+    return WillPopScope(
+      onWillPop: () async => false,
+      child: AlertDialog(
+        backgroundColor: widget.backgroundColor,
+        shape: RoundedRectangleBorder(
+          side: BorderSide(
+            color: widget.borderColor,
+            width: widget.borderWidth,
+          ),
+          borderRadius: BorderRadius.circular(widget.borderRadius),
+        ),
+        title: Text(
+          widget.titleText,
+          style: TextStyle(
+            fontSize: widget.titleSize,
+            color: widget.titleColor,
+          ),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: EdgeInsets.only(
+                bottom: 15,
+                left: widget.horizontalPadding,
+                right: widget.horizontalPadding,
+              ),
+              child: StatefulBuilder(
+                builder: (context, setState) {
+                  Timer.periodic(Duration(seconds: 1), (timer) {
+                    if (activeButtons) timer.cancel();
+                    if (mounted) setState(() {});
+                  });
+                  return Column(
+                    children: [
+                      widget.isSimpleDescription
+                          ? Text(
+                              widget.descriptionText,
+                              style: TextStyle(
+                                fontSize: widget.descriptionSize,
+                                color: widget.descriptionColor,
+                              ),
+                            )
+                          : widget.customDescription ??
+                              Text(
+                                'Missing custom description',
+                                style: TextStyle(
+                                  fontSize: widget.descriptionSize,
+                                  color: widget.descriptionColor,
+                                ),
+                              ),
+                      if (!activeButtons)
+                        Text(
+                          "Available in ${widget.timerDuration - countTime}",
+                          style: TextStyle(
+                            color: Color(0xFFB5a689),
+                          ),
+                        ),
+                    ],
+                  );
+                },
+              ),
+            ),
+            (widget.isSingleButton)
+                ? ActionButtonComponent(
+                    highlightColor: widget.okButtonHighlightColor,
+                    hoverColor: widget.okButtonHoverColor,
+                    width: widget.okButtonWidth,
+                    borderRadius: widget.okButtonBorderRadius,
+                    borderColor: widget.okButtonBorderColor,
+                    backgroundColor: widget.okButtonBackgroundColor,
+                    textColor: widget.okButtonTextColor,
+                    labelText: widget.okButtonText,
+                    onPressedCallback: () {
+                      if (activeButtons) widget.onOkCallback();
+                    },
+                    onLongPressedCallback: () {},
+                  )
+                : Wrap(
+                    spacing: 10,
+                    children: [
+                      ActionButtonComponent(
+                        highlightColor: widget.cancelButtonHighlightColor,
+                        hoverColor: widget.cancelButtonHoverColor,
+                        width: widget.cancelButtonWidth,
+                        borderRadius: widget.cancelButtonBorderRadius,
+                        borderColor: widget.cancelButtonBorderColor,
+                        backgroundColor: widget.cancelButtonBackgroundColor,
+                        textColor: widget.cancelButtonTextColor,
+                        labelText: widget.cancelButtonText,
+                        onPressedCallback: () {
+                          if (activeButtons) widget.onCancelCallback();
+                        },
+                        onLongPressedCallback: () {},
+                      ),
+                      ActionButtonComponent(
+                        highlightColor: widget.okButtonHighlightColor,
+                        hoverColor: widget.okButtonHoverColor,
+                        width: widget.okButtonWidth,
+                        borderRadius: widget.okButtonBorderRadius,
+                        borderColor: widget.okButtonBorderColor,
+                        backgroundColor: widget.okButtonBackgroundColor,
+                        textColor: widget.okButtonTextColor,
+                        labelText: widget.okButtonText,
+                        onPressedCallback: () {
+                          if (activeButtons) widget.onOkCallback();
+                        },
+                        onLongPressedCallback: () {},
+                      ),
+                    ],
+                  ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/nfc_flutter/pubspec.lock
+++ b/nfc_flutter/pubspec.lock
@@ -214,6 +214,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "9.1.0"
   frontend_server_client:
     dependency: transitive
     description:

--- a/nfc_flutter/pubspec.lock
+++ b/nfc_flutter/pubspec.lock
@@ -209,6 +209,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_nfc_kit:
+    dependency: "direct main"
+    description:
+      name: flutter_nfc_kit
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -305,13 +312,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  nfc_manager:
-    dependency: "direct main"
+  ndef:
+    dependency: transitive
     description:
-      name: nfc_manager
+      name: ndef
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "0.3.1"
   package_config:
     dependency: transitive
     description:
@@ -443,6 +450,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.4"
   vector_math:
     dependency: transitive
     description:
@@ -473,4 +487,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=2.0.0"

--- a/nfc_flutter/pubspec.lock
+++ b/nfc_flutter/pubspec.lock
@@ -298,6 +298,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  nfc_manager:
+    dependency: "direct main"
+    description:
+      name: nfc_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   package_config:
     dependency: transitive
     description:
@@ -459,3 +466,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"

--- a/nfc_flutter/pubspec.lock
+++ b/nfc_flutter/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   args:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   auto_route:
     dependency: "direct main"
     description:
@@ -119,7 +119,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -297,7 +297,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -428,7 +428,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   timing:
     dependency: transitive
     description:

--- a/nfc_flutter/pubspec.yaml
+++ b/nfc_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 0.1.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -25,6 +25,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
+  nfc_manager: ^3.1.0
 
 dev_dependencies:
   auto_route_generator: null

--- a/nfc_flutter/pubspec.yaml
+++ b/nfc_flutter/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
+  font_awesome_flutter: ^9.1.0
   nfc_manager: ^3.1.0
 
 dev_dependencies:

--- a/nfc_flutter/pubspec.yaml
+++ b/nfc_flutter/pubspec.yaml
@@ -25,8 +25,8 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
+  flutter_nfc_kit: ^3.0.0
   font_awesome_flutter: ^9.1.0
-  nfc_manager: ^3.1.0
 
 dev_dependencies:
   auto_route_generator: null


### PR DESCRIPTION
The main purpose is to be able to detect NFC tags and retrieve simple data from it (specifically the tag identifier and the tag content message/data) in a way that's simple to understand and implement for future use of the technology.

It's done by using the flutter_nfc_kit package (at the beginning the nfc_manager package was used, but it did not allow to reach the desired result, so it was replaced by the flutter_nfc_kit package instead).